### PR TITLE
(DEV-202) handle unescaped ampersands in filename

### DIFF
--- a/lib/vzaar/request/url.rb
+++ b/lib/vzaar/request/url.rb
@@ -15,8 +15,8 @@ module Vzaar
       end
 
       def build_params
-        _params = params ? (params.delete_if {|k,v| v.nil?}) : {}
-        URI.escape(_params.collect { |k,v| "#{k}=#{v}" }.join('&'))
+        _params = params ? (params.delete_if { |k,v| v.nil? }) : {}
+        URI.encode_www_form(_params)
       end
 
     end

--- a/spec/vzaar/request/url_spec.rb
+++ b/spec/vzaar/request/url_spec.rb
@@ -2,24 +2,31 @@ require 'spec_helper'
 require './lib/vzaar/request/url'
 
 describe Vzaar::Request::Url do
-  let(:params) do
-    { foo: 1, bar: 2 }
-  end
-
   let(:format) { :xml }
-
   let(:url) { "/api/endpoint" }
 
   subject { described_class.new(url, format, params) }
 
   describe "#build" do
+    let(:result) { subject.build }
+
     context "when there are params" do
-      specify { expect(subject.build).to eq("/api/endpoint.xml?foo=1&bar=2") }
+      let(:params) { { foo: 1, bar: 2 } }
+      let(:expected_result) { "/api/endpoint.xml?foo=1&bar=2" }
+      specify { expect(result).to eq expected_result }
+
+      context 'and the params contain an unescaped ampersand' do
+        let(:params) { { foo: 'this & that.mp4', bar: 2 } }
+        let(:encoded_params) { URI.encode_www_form params }
+        let(:expected_result) { "/api/endpoint.xml?#{encoded_params}" }
+        specify { expect(result).to eq expected_result }
+      end
     end
 
     context "when there are params" do
       let(:params) {{}}
-      specify { expect(subject.build).to eq("/api/endpoint.xml") }
+      let(:expected_result) { "/api/endpoint.xml" }
+      specify { expect(result).to eq expected_result }
     end
   end
 end


### PR DESCRIPTION
#### Summary
If your filename contains an ampersand the upload will fail. Actually, the file itself will be uploaded but the encoding will fail because the unescaped ampersand results in an invalid key when creating the multipart-upload on S3.

#### Intended effect
Ampersands are CGI-escaped prior to extracting attributes from the request body. Additionally, as the Ruby lib sends XML requests, any filename containing an ampersand results in an exception because whilst we receive the XML request body, it cannot be parsed correctly as technically it is invalid XML.

#### How I tested
I used the following Ruby script for testing the API lib. Run this from the root folder of the Ruby API repo.
When you hit the `pry` binding, you can check the contents of the `v1` and `v2` variables to ensure the videos are valid. Also check the APP UI to ensure they are encoded (obviously!).

```
load 'lib/vzaar.rb'
require 'pry'

server = 'app.vzaar.localhost'
login = '___'
token = '___'

api = Vzaar::Api.new(force_http: true,
  application_token: token, login: login, server: server)

puts "My login: #{api.whoami}"

print 'Uploading large video...'
v1 = api.upload_video(title: "multipart", path: "./this & that.mp4")
v2 = api.upload_video(title: "multipart", path: "./only-this.mp4")
binding.pry
```
