### PR TITLE
(DEV-202) handle unescaped ampersands in filename

### DIFF
--- a/lib/vzaar/request/url.rb
+++ b/lib/vzaar/request/url.rb
@@ -15,8 +15,8 @@ module Vzaar
       end
 
       def build_params
-        _params = params ? (params.delete_if {|k,v| v.nil?}) : {}
-        URI.escape(_params.collect { |k,v| "#{k}=#{v}" }.join('&'))
+        _params = params ? (params.delete_if { |k,v| v.nil? }) : {}
+        URI.encode_www_form(_params)
       end
 
     end

--- a/spec/vzaar/request/url_spec.rb
+++ b/spec/vzaar/request/url_spec.rb
@@ -2,24 +2,31 @@ require 'spec_helper'
 require './lib/vzaar/request/url'
 
 describe Vzaar::Request::Url do
-  let(:params) do
-    { foo: 1, bar: 2 }
-  end
-
   let(:format) { :xml }
-
   let(:url) { "/api/endpoint" }
 
   subject { described_class.new(url, format, params) }
 
   describe "#build" do
+    let(:result) { subject.build }
+
     context "when there are params" do
-      specify { expect(subject.build).to eq("/api/endpoint.xml?foo=1&bar=2") }
+      let(:params) { { foo: 1, bar: 2 } }
+      let(:expected_result) { "/api/endpoint.xml?foo=1&bar=2" }
+      specify { expect(result).to eq expected_result }
+
+      context 'and the params contain an unescaped ampersand' do
+        let(:params) { { foo: 'this & that.mp4', bar: 2 } }
+        let(:encoded_params) { URI.encode_www_form params }
+        let(:expected_result) { "/api/endpoint.xml?#{encoded_params}" }
+        specify { expect(result).to eq expected_result }
+      end
     end
 
     context "when there are params" do
       let(:params) {{}}
-      specify { expect(subject.build).to eq("/api/endpoint.xml") }
+      let(:expected_result) { "/api/endpoint.xml" }
+      specify { expect(result).to eq expected_result }
     end
   end
 end


### PR DESCRIPTION
#### Summary
This is a small change to handle encoding of parameters in the filename parameter.

#### Intended effect
No change in behaviour.

#### How I tested
This was tested as part of [this pull request](https://github.com/vzaar/vzaar-app/pull/681).