### PR TITLE
(CB-603) add uploader metadata to S3 file uploads

### DIFF
--- a/lib/vzaar.rb
+++ b/lib/vzaar.rb
@@ -30,7 +30,7 @@ require 'nokogiri'
 require 'oauth'
 require 'json'
 
-
+require 'vzaar/version'
 require 'vzaar/request/multipart'
 require 'vzaar/ext/oauth'
 require 'vzaar/connection'
@@ -40,8 +40,6 @@ require 'vzaar/request/base'
 
 require 'vzaar/resources/base'
 require 'vzaar/resources/account_type'
-
-
 require 'vzaar/resources/user'
 require 'vzaar/resources/video'
 require 'vzaar/resources/video_status'
@@ -69,16 +67,11 @@ require 'vzaar/request/link_upload'
 require 'vzaar/request/generate_thumbnail'
 require 'vzaar/request/upload_thumbnail'
 require 'vzaar/request/add_subtitle'
-
-
 require 'vzaar/uploader'
-
 
 # response
 
 require 'vzaar/response/base'
-
-
 require 'vzaar/request/edit_video'
 require 'vzaar/request/process_video'
 require 'vzaar/request/process_audio'

--- a/lib/vzaar/request/signature.rb
+++ b/lib/vzaar/request/signature.rb
@@ -20,6 +20,7 @@ module Vzaar
         if options[:path]
           _params[:filename] = File.basename(options[:path])
           _params[:filesize] = File::Stat.new(options[:path]).size
+          _params[:uploader] = "Ruby #{VERSION}"
         end
         if options[:success_action_redirect]
           _params[:success_action_redirect] = options[:success_action_redirect]

--- a/lib/vzaar/uploaders/s3.rb
+++ b/lib/vzaar/uploaders/s3.rb
@@ -57,7 +57,6 @@ module Vzaar
         File.open(path, "r") do |file|
           until file.eof?
             _headers['chunk'] = chunk
-            _headers['x-amz-meta-uploader'] = "Ruby #{VERSION}"
             _headers['key'] = "#{signature.key}.#{chunk}"
             _headers['file'] = VirtualFile.new(file, chunk_size_bytes)
 
@@ -78,7 +77,8 @@ module Vzaar
           'success_action_status' => '201',
           'policy' => signature.policy,
           'AWSAccessKeyId' => signature.access_key_id,
-          'signature' => signature.signature
+          'signature' => signature.signature,
+          'x-amz-meta-uploader' => "Ruby #{VERSION}"
         }
       end
 

--- a/lib/vzaar/uploaders/s3.rb
+++ b/lib/vzaar/uploaders/s3.rb
@@ -57,6 +57,7 @@ module Vzaar
         File.open(path, "r") do |file|
           until file.eof?
             _headers['chunk'] = chunk
+            _headers['x-amz-meta-uploader'] = "Ruby #{VERSION}"
             _headers['key'] = "#{signature.key}.#{chunk}"
             _headers['file'] = VirtualFile.new(file, chunk_size_bytes)
 

--- a/spec/fixtures/vcr_cassettes/signature-default.yml
+++ b/spec/fixtures/vcr_cassettes/signature-default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&multipart=true
+    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&multipart=true&uploader=Ruby%201.6.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/signature-with-options.yml
+++ b/spec/fixtures/vcr_cassettes/signature-with-options.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&include_metadata=yes&multipart=true&success_action_redirect=example.com
+    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&include_metadata=yes&multipart=true&success_action_redirect=example.com&uploader=Ruby%201.6.1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/upload_video-success.yml
+++ b/spec/fixtures/vcr_cassettes/upload_video-success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&multipart=true
+    uri: https://vzaar.com/api/v1.1/videos/signature.xml?filename=video.mp4&filesize=258430&multipart=true&uploader=Ruby%201.6.1
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
#### Summary
To improve our ability to filter and troubleshoot API uploads more effectively, we now add metadata to S3 file uploads.

#### Intended effect
This change sends the `uploader` information to the signature endpoint which will return an S3 policy that expects an additional metadata header added to the S3 file upload: `x-amz-meta-uploader`

#### How I tested
This change was fully tested as part of [this APP pull request](https://github.com/vzaar/vzaar-app/pull/712).

#### Comments
The aforementioned APP pull request _must_ be merged and deployed to production _before_ this change is accepted.