### PR TITLE
(DEV-1007) Adds support for custom playlist ordering

### DIFF
--- a/lib/vzaar_api/playlist.rb
+++ b/lib/vzaar_api/playlist.rb
@@ -10,7 +10,7 @@ module VzaarApi
 
     ATTR_ACCESSORS = %i(
       category_id title sort_by sort_order private dimensions max_vids
-      position autoplay continuous_play max_vids
+      position autoplay continuous_play max_vids video_ids
     ).freeze
 
     prepend Lib::HasAttributes

--- a/lib/vzaar_api/version.rb
+++ b/lib/vzaar_api/version.rb
@@ -1,4 +1,4 @@
 module VzaarApi
-  VERSION  = '2.0.0'
+  VERSION  = '2.0.1'
   UPLOADER = 'Ruby-2.0.0'
 end


### PR DESCRIPTION
### Summary 
These changes add support for custom playlist ordering. 

They make it possible to send an ordered array of video IDs, within a playlist create or update request.

### Testing
To test this simply try creating a playlist with a custom sort order and include video IDs in the params. Like so...
```ruby
VzaarApi::Playlist.create(title: "Playlist Test", category_id: 13405, sort_by: "custom", video_ids: [12271388, 1227139411, 12271390, 12271389])
```
... if the request is successful, you'll see videos displayed in the appropriate order in the playlist. 

Any videos not listed in the `video_ids` param, but present in the category, will appear last in the order.

### Notes
At present these changes do not affect GET requests for playlists. For those to return the `video_ids` field, we'll need to make some changes on the APP side of things.