### PR TITLE
Don't package specs and examples in gem

### DIFF
--- a/vzaar_api.gemspec
+++ b/vzaar_api.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
   s.rubygems_version      = ">= 2.5"
 
-  s.files         = `git ls-files`.split($/)
+  s.files         = `git ls-files lib README.md`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.test_files    = s.files.grep(%r{^(spec)/})
   s.require_paths = ['lib']
 
   s.add_dependency 'httpclient', '~> 2.8'


### PR DESCRIPTION
The vzaar gem currently weighs in at over 50MB, largely due to video support files and fixtures in the spec and examples directories. This can have a significant impact on CI systems and build artifact size, e.g. docker containers.

These files aren't necessary to use the gem, so this change removes them from the gemspec's `files` declaration, including only the `lib/` directory and `README`.